### PR TITLE
Change apt-get to apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Graphical user interface to create snaps using snapcraft as backend , written in
 
 	sudo add-apt-repository ppa:keshavnrj/snapcraft-gui-nightly
 
-	sudo apt-get update
+	sudo apt update
 	
 	sudo apt install snapcraft-gui
 


### PR DESCRIPTION
`apt` is the new interface recommended by the `apt-get`/`apt` team that replaces `apt-get` and adds new functionality like a progress bar.

Your instructions should be updated appropriately.